### PR TITLE
Fixed issue of multiple device registration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,8 @@ android {
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"
+        // Enabling multidex support.
+        multiDexEnabled true
     }
     buildTypes {
         release {

--- a/app/src/main/java/edu/cs65/caregiver/caregiver/AccountSignOnActivity.java
+++ b/app/src/main/java/edu/cs65/caregiver/caregiver/AccountSignOnActivity.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.HashMap;
 
+import edu.cs65.caregiver.caregiver.controllers.DataController;
 import edu.cs65.caregiver.caregiver.model.CareGiver;
 
 public class AccountSignOnActivity extends Activity {
@@ -36,14 +37,16 @@ public class AccountSignOnActivity extends Activity {
     private static final String REGISTRATION_KEY = "registration key";
     private static final String RECIPIENT_NAME_KEY = "recipient name";
     private static final String SERVER_ADDR = "https://handy-empire-131521.appspot.com";
+    private static DataController mDc;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_new_account);
+        mDc = DataController.getInstance(getApplicationContext());
         mContext = getApplicationContext();
-
-        registrationID = MainActivity.mRegistrationID;
+        registrationID = mDc.getRegistrationId();
+        //registrationID = MainActivity.mRegistrationID;
         history = 0;
     }
 

--- a/app/src/main/java/edu/cs65/caregiver/caregiver/CareGiverActivity.java
+++ b/app/src/main/java/edu/cs65/caregiver/caregiver/CareGiverActivity.java
@@ -150,7 +150,8 @@ public class CareGiverActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        new GcmUnRegistrationAsyncTask(this).execute();
+        // We do NOT want to unregister our GCM in onDestroy().
+        //new GcmUnRegistrationAsyncTask(this).execute();
 
     }
 

--- a/app/src/main/java/edu/cs65/caregiver/caregiver/Globals.java
+++ b/app/src/main/java/edu/cs65/caregiver/caregiver/Globals.java
@@ -1,0 +1,17 @@
+package edu.cs65.caregiver.caregiver;
+
+/**
+ * Created by don on 5/29/16.
+ */
+public class Globals {
+    public static final String PREFS_VERSION_KEY = "version";
+    static final String TAG = "CareGiverActivity";
+    // Changed sender id
+    static final String SENDER_ID = "1059275309009";
+    static final String ACCNT_KEY = "account key";
+    static final String EMAIL_KEY = "email key";
+    private static final String REGISTRATION_KEY = "registration key";
+    public static String SERVER_ADDR = "https://handy-empire-131521.appspot.com";
+    public static final String APP_VERSION_PREFS_FILE = "app_version_prefs_file";
+    public static final String REG_PREF_FILE = "registration_pref_file";
+}

--- a/app/src/main/java/edu/cs65/caregiver/caregiver/MainActivity.java
+++ b/app/src/main/java/edu/cs65/caregiver/caregiver/MainActivity.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 
@@ -17,46 +19,64 @@ import android.widget.Toast;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.google.api.client.extensions.android.http.AndroidHttp;
 import com.google.api.client.extensions.android.json.AndroidJsonFactory;
-import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.cs65.caregiver.backend.registration.Registration;
-import edu.cs65.caregiver.caregiver.model.CareGiver;
+import edu.cs65.caregiver.caregiver.controllers.DataController;
 
 public class MainActivity extends Activity {
 
     private final int SPLASH_DISPLAY_LENGTH = 3250;
-    public static String SERVER_ADDR = "https://handy-empire-131521.appspot.com";
-    private static final String TAG = "CareGiverActivity";
 
-    // Changed sender id
-    private static final String SENDER_ID = "1059275309009";
     public static String mRegistrationID;
 
-    private static final String ACCNT_KEY = "account key";
-    private static final String EMAIL_KEY = "email key";
-    private static final String REGISTRATION_KEY = "registration key";
+    private static DataController mDc;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        new GcmRegistrationAsyncTask(this).execute();
+        mDc = DataController.getInstance(getApplicationContext());
+        mDc.initializeData(getApplicationContext());
 
-        SharedPreferences.Editor editor = getSharedPreferences(getString(R.string.profile_preference), MODE_PRIVATE).edit();
-        editor.clear();
-        editor.apply();
+        //new GcmRegistrationAsyncTask(this).execute();
+
+        String versionCode = "";
+        try {
+            PackageInfo packageInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
+            versionCode = String.valueOf(packageInfo.versionCode);
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        String savedVersion = mDc.getStringFromPreferences(Globals.APP_VERSION_PREFS_FILE,
+                Globals.PREFS_VERSION_KEY);
+        if (savedVersion.equals("")) {
+            // First time loading application. Get a new registration ID
+            // Deregister if previous registration ID available, and register.
+            new GcmRegistrationAsyncTask(this).execute();
+            mDc.saveToPreferences(Globals.APP_VERSION_PREFS_FILE, Globals.PREFS_VERSION_KEY, versionCode);
+        } else if (!versionCode.equals(savedVersion)) {
+            // Updated version. Deregister previous registration ID and re-register.
+            new GcmUnRegistrationAsyncTask(this, savedVersion).execute();
+            new GcmRegistrationAsyncTask(this).execute();
+            mDc.saveToPreferences(Globals.APP_VERSION_PREFS_FILE, Globals.PREFS_VERSION_KEY, versionCode);
+        }
+
+        // TODO: REMOVE FOR PRODUCTION
+//        SharedPreferences.Editor editor = getSharedPreferences(getString(R.string.profile_preference), MODE_PRIVATE).edit();
+//        editor.clear();
+//        editor.apply();
 
         SharedPreferences preferences = getSharedPreferences(getString(R.string.profile_preference), 0);
 
-        if (!preferences.getString(EMAIL_KEY,"").equals("")){
-            if (preferences.getString(ACCNT_KEY,"").equals("care recipient")){
+        if (!preferences.getString(Globals.EMAIL_KEY,"").equals("")){
+            if (preferences.getString(Globals.ACCNT_KEY,"").equals("care recipient")){
                 Intent newMedication = new Intent(getApplicationContext(), CareRecipientActivity.class);
                 startActivity(newMedication);
                 finish();
-            } else if (preferences.getString(ACCNT_KEY,"").equals("caregiver")){
+            } else if (preferences.getString(Globals.ACCNT_KEY,"").equals("caregiver")){
                 Intent newMedication = new Intent(getApplicationContext(), CareGiverActivity.class);
                 startActivity(newMedication);
                 finish();
@@ -93,7 +113,7 @@ public class MainActivity extends Activity {
             if (regService == null) {
                 Registration.Builder builder = new Registration.Builder(AndroidHttp.newCompatibleTransport(),
                         new AndroidJsonFactory(), null)
-                        .setRootUrl(SERVER_ADDR + "/_ah/api/");
+                        .setRootUrl(Globals.SERVER_ADDR + "/_ah/api/");
 
                 regService = builder.build();
             }
@@ -103,7 +123,8 @@ public class MainActivity extends Activity {
                 if (gcm == null) {
                     gcm = GoogleCloudMessaging.getInstance(context);
                 }
-                mRegistrationID = gcm.register(SENDER_ID);
+                mRegistrationID = gcm.register(Globals.SENDER_ID);
+                mDc.saveRegistrationId(mRegistrationID);
                 msg = "Device registered, registration ID = " + mRegistrationID;
 
                 // Send registration ID to server over HTTP so it can use GCM/HTTP
@@ -112,7 +133,7 @@ public class MainActivity extends Activity {
 
             } catch (IOException ex) {
                 ex.printStackTrace();
-                Log.d(TAG, "Error: " + ex.getMessage());
+                Log.d(Globals.TAG, "Error: " + ex.getMessage());
                 msg = null;
             }
             return msg;
@@ -128,6 +149,55 @@ public class MainActivity extends Activity {
             } else {
                 Toast.makeText(context, "Failed to Connect to Cloud", Toast.LENGTH_SHORT).show();
             }
+        }
+    }
+
+    class GcmUnRegistrationAsyncTask extends AsyncTask<Void, Void, Void> {
+        private Registration regService = null;
+        private GoogleCloudMessaging gcm;
+        private Context context;
+        private String regId;
+
+        public GcmUnRegistrationAsyncTask(Context context) {
+            this.context = context;
+        }
+
+        public GcmUnRegistrationAsyncTask(Context context, String regId) {
+            this.context = context;
+            this.regId = regId;
+
+        }
+
+        @Override
+        protected Void doInBackground(Void... params) {
+            if (regService == null) {
+                Registration.Builder builder = new Registration.Builder(AndroidHttp.newCompatibleTransport(),
+                        new AndroidJsonFactory(), null)
+                        .setRootUrl(Globals.SERVER_ADDR + "/_ah/api/");
+
+                regService = builder.build();
+            }
+
+            String msg = "";
+            try {
+                if (gcm == null) {
+                    gcm = GoogleCloudMessaging.getInstance(context);
+                }
+
+                if (regId != null) {
+                    regService.unregister(regId).execute();
+                }
+                gcm.unregister();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+                Log.d(Globals.TAG, "Error: " + ex.getMessage());
+                msg = null;
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void msg) {
         }
     }
 

--- a/app/src/main/java/edu/cs65/caregiver/caregiver/NewAccountSignUp.java
+++ b/app/src/main/java/edu/cs65/caregiver/caregiver/NewAccountSignUp.java
@@ -57,10 +57,12 @@ public class NewAccountSignUp extends Activity {
         passText = (EditText)findViewById(R.id.password);
 
         valid = false;
-        registrationID = MainActivity.mRegistrationID;
 
         mDataController = DataController.getInstance(getApplicationContext());
         mDataController.initializeData(getApplicationContext());
+
+        registrationID = mDataController.getRegistrationId();
+        //registrationID = MainActivity.mRegistrationID;
     }
 
     // once a new caregiver is created, take them to the medication page

--- a/app/src/main/java/edu/cs65/caregiver/caregiver/controllers/DataController.java
+++ b/app/src/main/java/edu/cs65/caregiver/caregiver/controllers/DataController.java
@@ -7,6 +7,8 @@ import android.util.Log;
 import com.google.gson.Gson;
 
 import edu.cs65.caregiver.backend.messaging.model.CaregiverEndpointsObject;
+import edu.cs65.caregiver.caregiver.Globals;
+import edu.cs65.caregiver.caregiver.R;
 import edu.cs65.caregiver.caregiver.model.CareGiver;
 import edu.cs65.caregiver.caregiver.model.Recipient;
 
@@ -47,11 +49,6 @@ public class DataController {
     public void initializeData(Context context) {
         // call this with application context so that the DataController can access resources etc.
         this.context = context.getApplicationContext();
-
-//        if (careGiver == null) {
-//            careGiver = new CareGiver(user);
-//            saveData();
-//        }
     }
 
     public void setData(CareGiver newCareGiver) {
@@ -77,6 +74,32 @@ public class DataController {
         String saved_data = gson.toJson(careGiver);
         prefsEditor.putString(SAVED_DATA_KEY, saved_data);
         prefsEditor.commit();
+    }
+
+    public void saveRegistrationId(String regId) {
+        SharedPreferences preferences = context.getSharedPreferences(Globals.REG_PREF_FILE, Context.MODE_PRIVATE);
+        SharedPreferences.Editor prefsEditor = preferences.edit();
+        prefsEditor.putString("regId", regId);
+        prefsEditor.commit();
+    }
+
+    public String getRegistrationId() {
+        SharedPreferences preferences = context.getSharedPreferences(Globals.REG_PREF_FILE, Context.MODE_PRIVATE);
+        return preferences.getString("regId", "");
+    }
+
+    public void saveToPreferences(String prefsFileName, String key, String value) {
+        SharedPreferences preferences = context.getSharedPreferences(
+                prefsFileName, Context.MODE_PRIVATE);
+        SharedPreferences.Editor prefsEditor = preferences.edit();
+        prefsEditor.putString(key, value);
+        prefsEditor.apply();
+    }
+
+    public String getStringFromPreferences(String prefsFileName, String key) {
+        SharedPreferences preferences = context.getSharedPreferences(
+                prefsFileName, Context.MODE_PRIVATE);
+        return preferences.getString(key, "");
     }
 
     public void loadData() {


### PR DESCRIPTION
Using online documentation of the GCM register function, I've rewritten the app side for app registration. Now, we only register a device on first launch OR if the app has been updated. In the latter case, we unregister the previous ID. This commit has been tested to eliminate the issue of multiple alarms being triggered at once. Since it relies on saving the registration ID to a sharedPreferences file on first launch, you may need to remove the app and its associated cache file / settings in order for things to work properly.
